### PR TITLE
feat: new optional contextDepth for archy renderer

### DIFF
--- a/lib/utils/archyTree.ts
+++ b/lib/utils/archyTree.ts
@@ -5,7 +5,7 @@ import * as archy from 'archy';
 import {Data} from 'archy';
 
 function buildArchyTree<S extends BlueshellState, E>(
-	node: Base<S, E>, state?: S, contextDepth = Number.MAX_SAFE_INTEGER
+	node: Base<S, E>, contextDepth: number, state?: S
 ): Required<Data>|undefined {
 	let label = node.name;
 
@@ -43,7 +43,8 @@ function buildArchyTree<S extends BlueshellState, E>(
 
 	if ((<any>node).children) {
 		for (const child of (<any>node).children) {
-			const subTree = buildArchyTree(<Base<S, E>>child, state, contextDepth - (onPath ? 0 : 1));
+			const childDepth = contextDepth - (onPath ? 0 : 1);
+			const subTree = buildArchyTree(<Base<S, E>>child, childDepth, state);
 			if (subTree) {
 				nodes.push(subTree);
 			}
@@ -59,8 +60,8 @@ function buildArchyTree<S extends BlueshellState, E>(
 export function serializeArchyTree<S extends BlueshellState, E>(
 	tree: Base<S, E>, state?: S, contextDepth = Number.MAX_SAFE_INTEGER
 ): string {
-	const archyTree = buildArchyTree(tree, state, contextDepth);
-	if ( archyTree ) {
+	const archyTree = buildArchyTree(tree, contextDepth, state);
+	if (archyTree) {
 		return archy(archyTree);
 	}
 	return '';

--- a/lib/utils/archyTree.ts
+++ b/lib/utils/archyTree.ts
@@ -39,8 +39,6 @@ function buildArchyTree<S extends BlueshellState, E>(
 		}
 	}
 
-	label += `(${contextDepth})`;
-
 	const nodes = [];
 
 	if ((<any>node).children) {

--- a/lib/utils/renderTree.ts
+++ b/lib/utils/renderTree.ts
@@ -6,12 +6,16 @@ import {BlueshellState} from '../nodes/BlueshellState';
 import {serializeArchyTree} from './archyTree';
 import {serializeDotTree} from './dotTree';
 
-export function toString<S extends BlueshellState, E>(tree: Base<S, E>, state?: S): string {
-	return serializeArchyTree(tree, state);
+export function toString<S extends BlueshellState, E>(
+	tree: Base<S, E>, state?: S, contextDepth = Number.MAX_SAFE_INTEGER
+): string {
+	return serializeArchyTree(tree, state, contextDepth);
 }
 
-export function toConsole<S extends BlueshellState, E>(tree: Base<S, E>, state?: S) {
-	console.log(toString(tree, state)); // eslint-disable-line no-console
+export function toConsole<S extends BlueshellState, E>(
+	tree: Base<S, E>, state?: S, contextDepth = Number.MAX_SAFE_INTEGER
+) {
+	console.log(toString(tree, state, contextDepth)); // eslint-disable-line no-console
 }
 
 export function toDotString<S extends BlueshellState, E>(tree: Base<S, E>, state?: S) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4816,6 +4816,12 @@
             "interpret": "^1.0.0",
             "rechoir": "^0.6.2"
           }
+        },
+        "typescript": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+          "dev": true
         }
       }
     },
@@ -4826,9 +4832,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha1-LWFaHvSu5PV0Qlzf9wJu34GRmDY=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
     },
     "typescript-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "sinon": "^4.4.2",
     "ts-node": "^5.0.0",
     "typedoc": "^0.11.1",
-    "typescript": "^2.7.2",
+    "typescript": "2.9.2",
     "typescript-eslint-parser": "^14.0.0",
     "validate-commit-msg": "^2.14.0"
   },

--- a/test/utils/renderTree.test.ts
+++ b/test/utils/renderTree.test.ts
@@ -90,30 +90,30 @@ describe('renderTree', function() {
 				}
 			}
 			context('before running', function() {
-				it('should show nothing with -1 context depth', function() {
+				it('should show everything at unspecified context depth', function() {
+					runContextDepthTest(undefined, 11, 0, 0);
+				});
+				it('should show nothing at -1 context depth', function() {
 					runContextDepthTest(-1, 0, 0, 0);
 				});
-				it('should show root ellipsis with 0 context depth', function() {
+				it('should show root ellipsis at 0 context depth', function() {
 					runContextDepthTest(0, 1, 1, 0);
-				});
-				it('should show everything by default', function() {
-					runContextDepthTest(undefined, 11, 0, 0);
 				});
 			});
 			context('after one run', function() {
 				beforeEach(async function() {
 					await testTree.handleEvent(state, {});
 				});
-				it('should arrow the first path by default', function() {
+				it('should arrow the first path at unspecified context depth', function() {
 					runContextDepthTest(undefined, 11, 0, 4);
-				});
-				it('should show only the active path and ellipses 0 context depth', function() {
-					runContextDepthTest(0, 7, 3, 4);
 				});
 				it('should show only the active path at -1 context depth', function() {
 					runContextDepthTest(-1, 4, 0, 4);
 				});
-				it('should show only the active path, siblings, and ellipses', function() {
+				it('should show only the active path and ellipses at 0 context depth', function() {
+					runContextDepthTest(0, 7, 3, 4);
+				});
+				it('should show only the active path, siblings, and ellipses at 1 context depth', function() {
 					runContextDepthTest(1, 11, 4, 4);
 				});
 				it('should show everything at 2 context depth', function() {


### PR DESCRIPTION
This adds an optional contextDepth parameter when using the archy renderer for the behavior tree.

Leaving out this optional parameter causes the existing behavior.

Describing the effect when the parameter *is* used is best done by example. Here are the unit tests for the new behavior, with the addition of showing the output they are testing:

```

  renderTree
    archy tree
      contextDepth
        before running

          ✓ should show nothing with -1 context depth
...

          ✓ should show root ellipsis with 0 context depth
root (LatchedSequence)
├─┬ 0 (LatchedSequence)
│ ├─┬ 0.0 (LatchedSequence)
│ │ ├── 0.0.0 (ConsumeOnce)
│ │ └── 0.0.1 (ConsumeOnce)
│ └─┬ 0.1 (LatchedSequence)
│   ├── 0.1.0 (ConsumeOnce)
│   └── 0.1.1 (ConsumeOnce)
└─┬ 1 (LatchedSequence)
  ├── 1.0 (ConsumeOnce)
  └── 1.1 (ConsumeOnce)

          ✓ should show everything by default
        after one run
root (LatchedSequence) => RUNNING
├─┬ 0 (LatchedSequence) => RUNNING
│ ├─┬ 0.0 (LatchedSequence) => RUNNING
│ │ ├── 0.0.0 (ConsumeOnce) => RUNNING
│ │ └── 0.0.1 (ConsumeOnce)
│ └─┬ 0.1 (LatchedSequence)
│   ├── 0.1.0 (ConsumeOnce)
│   └── 0.1.1 (ConsumeOnce)
└─┬ 1 (LatchedSequence)
  ├── 1.0 (ConsumeOnce)
  └── 1.1 (ConsumeOnce)

          ✓ should arrow the first path by default
root (LatchedSequence) => RUNNING
├─┬ 0 (LatchedSequence) => RUNNING
│ ├─┬ 0.0 (LatchedSequence) => RUNNING
│ │ ├── 0.0.0 (ConsumeOnce) => RUNNING
│ │ └── ...
│ └── ...
└── ...

          ✓ should show only the active path and ellipses 0 context depth
root (LatchedSequence) => RUNNING
└─┬ 0 (LatchedSequence) => RUNNING
  └─┬ 0.0 (LatchedSequence) => RUNNING
    └── 0.0.0 (ConsumeOnce) => RUNNING

          ✓ should show only the active path at -1 context depth
root (LatchedSequence) => RUNNING
├─┬ 0 (LatchedSequence) => RUNNING
│ ├─┬ 0.0 (LatchedSequence) => RUNNING
│ │ ├── 0.0.0 (ConsumeOnce) => RUNNING
│ │ └── 0.0.1 (ConsumeOnce)
│ └─┬ 0.1 (LatchedSequence)
│   ├── ...
│   └── ...
└─┬ 1 (LatchedSequence)
  ├── ...
  └── ...

          ✓ should show only the active path, siblings, and ellipses
root (LatchedSequence) => RUNNING
├─┬ 0 (LatchedSequence) => RUNNING
│ ├─┬ 0.0 (LatchedSequence) => RUNNING
│ │ ├── 0.0.0 (ConsumeOnce) => RUNNING
│ │ └── 0.0.1 (ConsumeOnce)
│ └─┬ 0.1 (LatchedSequence)
│   ├── 0.1.0 (ConsumeOnce)
│   └── 0.1.1 (ConsumeOnce)
└─┬ 1 (LatchedSequence)
  ├── 1.0 (ConsumeOnce)
  └── 1.1 (ConsumeOnce)

          ✓ should show everything at 2 context depth


  8 passing (25ms)
```