### PR TITLE
feat: add When Composite node

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,6 +9,7 @@ export {Success} from './nodes/Success';
 export {LatchedSelector} from './nodes/LatchedSelector';
 export {LatchedSequence} from './nodes/LatchedSequence';
 export {IfElse} from './nodes/IfElse';
+export {When} from './nodes/When';
 export {resultCodes, ResultCode} from './utils/resultCodes';
 
 import * as decorators from './nodes/decorators';

--- a/lib/nodes/When.ts
+++ b/lib/nodes/When.ts
@@ -1,0 +1,44 @@
+import {Composite} from './Composite';
+import {BlueshellState} from './BlueshellState';
+import {resultCodes as rc, ResultCode} from '../utils/resultCodes';
+import {Base} from './Base';
+
+export interface Conditional<S, E> {
+	(state: S, event: E): boolean;
+}
+
+/**
+ * When Conditional Composite Node.
+ *
+ * If `conditional(state: S, event: E)` returns true,
+ * control is passed to the consequent node.
+ */
+export class When<S extends BlueshellState, E> extends Composite<S, E> {
+	constructor(name: string,
+	            private readonly conditional: Conditional<S, E>,
+							private readonly consequent: Base<S, E>,
+							private readonly result: ResultCode = rc.SUCCESS,
+							latched: boolean = false) {
+		super(name, [consequent], latched);
+	}
+
+	/**
+	 * If `conditional` resolves to `true`, then the `consequent` node handles the event.
+	 * Otherwise, this node resolves to `SUCCESS` or the provided result
+	 * @override
+	 * @param state The state when the event occured.
+	 * @param event The event to handle.
+	 * @param i The child index, which is always 0
+	 */
+	handleChild(state: S, event: E, i: number) {
+		if (this.conditional(state, event)) {
+			return this.consequent.handleEvent(state, event);
+		} else {
+			return this.result;
+		}
+	}
+
+	get symbol() {
+		return '?!';
+	}
+}

--- a/lib/nodes/When.ts
+++ b/lib/nodes/When.ts
@@ -30,7 +30,7 @@ export class When<S extends BlueshellState, E> extends Composite<S, E> {
 	 * @param event The event to handle.
 	 * @param i The child index, which is always 0
 	 */
-	handleChild(state: S, event: E, i: number) {
+	handleChild(state: S, event: E) {
 		if (this.conditional(state, event)) {
 			return this.consequent.handleEvent(state, event);
 		} else {

--- a/test/nodes/When.test.ts
+++ b/test/nodes/When.test.ts
@@ -1,6 +1,3 @@
-/**
- * Created by josh on 1/10/16.
- */
 import {assert} from 'chai';
 
 import {resultCodes as rc} from '../../lib/utils/resultCodes';

--- a/test/nodes/When.test.ts
+++ b/test/nodes/When.test.ts
@@ -105,7 +105,9 @@ describe('When', function() {
 		]);
 		const When = new Behavior.When('testWhen',
 			(state: TestState, event: string) => event !== 'ignore',
-			child
+			child,
+			rc.SUCCESS,
+			true,
 		);
 
 		const state = new TestState();

--- a/test/nodes/When.test.ts
+++ b/test/nodes/When.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Created by josh on 1/10/16.
+ */
+import {assert} from 'chai';
+
+import {resultCodes as rc} from '../../lib/utils/resultCodes';
+
+import * as Behavior from '../../lib';
+import {BlueshellState} from '../../lib/nodes/BlueshellState';
+
+class TestState implements BlueshellState {
+	public success: boolean = false;
+	public errorReason?: Error;
+	public __blueshell: any;
+}
+
+describe('When', function() {
+	const successAction = new (class extends Behavior.Action<TestState, string> {
+		onEvent(state: TestState) {
+			state.success = true;
+
+			return rc.SUCCESS;
+		}
+	})();
+
+	const failureAction = new (class extends Behavior.Action<TestState, string> {
+		onEvent(state: TestState) {
+			state.success = false;
+
+			return rc.FAILURE;
+		}
+	})();
+
+	it('should return success when conditional is true', function() {
+		const When = new Behavior.When('testWhen',
+			() => true,
+			successAction
+		);
+
+		const state = new TestState();
+		const res = When.handleEvent(state, 'testEvent');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.SUCCESS, 'Behavior Tree should return success');
+		assert.isTrue(state.success, 'Expected Action was not called');
+	});
+
+	it('should return success when conditional is false', function() {
+		const When = new Behavior.When('testWhen',
+			() => false,
+			failureAction,
+		);
+
+		const state = new TestState();
+		const res = When.handleEvent(state, 'testEvent');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.SUCCESS, 'Behavior Tree should return success');
+		assert.isNotTrue(state.success, 'Expected Action was not called');
+	});
+
+	it('should return failure when conditional is false', function() {
+		const When = new Behavior.When('testWhen',
+			() => false,
+			failureAction,
+			rc.FAILURE,
+		);
+
+		const state = new TestState();
+		const res = When.handleEvent(state, 'testEvent');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.FAILURE, 'Behavior Tree should return success');
+		assert.isNotTrue(state.success, 'Expected Action was not called');
+	});
+
+
+	it('should handle latched children', function() {
+		let failed = false;
+		const failOnceAction = new (class extends Behavior.Action<TestState, string> {
+			onEvent(state: TestState) {
+				if (!failed) {
+					state.success = false;
+					failed = true;
+					return rc.FAILURE;
+				}
+				state.success = true;
+				return rc.SUCCESS;
+			}
+		})();
+
+		let running = false;
+		const runningOnceAction = new (class extends Behavior.Action<TestState, string> {
+			onEvent(state: TestState) {
+				if (!running) {
+					state.success = false;
+					running = true;
+					return rc.RUNNING;
+				}
+				state.success = true;
+				return rc.SUCCESS;
+			}
+		})();
+		const child = new Behavior.LatchedSequence('testLatchedSequence', [
+			failOnceAction,
+			runningOnceAction,
+			successAction,
+		]);
+		const When = new Behavior.When('testWhen',
+			(state: TestState, event: string) => event !== 'ignore',
+			child
+		);
+
+		const state = new TestState();
+		let res = When.handleEvent(state, 'testEvent');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.FAILURE, 'Behavior Tree should return FAILURE');
+		assert.isNotTrue(state.success, 'state should not have success indication');
+
+		res = When.handleEvent(state, 'ignore');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.SUCCESS, 'Behavior Tree should return SUCCESS');
+		assert.isNotTrue(state.success, 'state should not have success indication');
+
+		res = When.handleEvent(state, 'testEvent');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.RUNNING, 'Behavior Tree should return SUCCESS');
+		assert.isNotTrue(state.success, 'state should not have success indication');
+
+		res = When.handleEvent(state, 'ignore');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.SUCCESS, 'Behavior Tree should return SUCCESS');
+		assert.isNotTrue(state.success, 'state should not have success indication');
+
+		res = When.handleEvent(state, 'testEvent');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.SUCCESS, 'Behavior Tree should return SUCCESS');
+		assert.isTrue(state.success, 'state should not have success indication');
+
+		res = When.handleEvent(state, 'testEvent');
+
+		assert.notOk(state.errorReason);
+		assert.strictEqual(res, rc.SUCCESS, 'Behavior Tree should return SUCCESS');
+	});
+});


### PR DESCRIPTION
I created this PR to address the issue that IfElse does not extend Composite and I often tend to use IfElse without an Else. This PR currently lacks a test that shows why extending Composite instead of Base is important.