### PR TITLE
Feat/chuck 5 logging

### DIFF
--- a/lib/models/BlueshellState.ts
+++ b/lib/models/BlueshellState.ts
@@ -4,4 +4,5 @@
 export interface BlueshellState {
 	errorReason?: Error;
 	__blueshell: any;
+	nodePath: string;
 }

--- a/lib/nodes/Base.ts
+++ b/lib/nodes/Base.ts
@@ -56,6 +56,7 @@ export class Base<S extends BlueshellState, E> implements BaseNode<S, E> {
 	 * @protected
 	 */
 	public handleEvent(state: S, event: E): ResultCode {
+		state.nodePath = this.path;
 		this._beforeEvent(state, event);
 
 		const passed = this.precondition(state, event);

--- a/lib/nodes/Composite.ts
+++ b/lib/nodes/Composite.ts
@@ -63,7 +63,11 @@ export abstract class Composite<S extends BlueshellState, E> extends Parent<S, E
 		if (this.latched) {
 			const storage = this.getNodeStorage(state);
 			// clear latched status if the node is no longer running after processing the event
-			if (storage.running !== undefined && res !== resultCodes.RUNNING) {
+			if (res !== resultCodes.RUNNING) {
+				const blueshell = this._privateStorage(state);
+				if (blueshell.loggingCallback) {
+					blueshell.loggingCallback(`Resetting latched status for node: ${this.path}`);
+				}
 				storage.running = undefined;
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pretest:eslint": "eslint --ext .ts,.js ${ESLINT_OPTS} .",
     "test": "NODE_ENV=test nyc mocha ${MOCHA_OPTS}",
     "test:no-cover": "NODE_ENV=test mocha",
-    "test:debug": "npm run test:no-cover -- --debug-brk test",
+    "test:debug": "npm run test:no-cover -- --inspect-brk test",
     "coverage": "NODE_ENV=test nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "prepublish": "npm-run-all clean compile"
   },

--- a/test/nodes/Base.test.ts
+++ b/test/nodes/Base.test.ts
@@ -11,6 +11,7 @@ const Decorator = Behavior.Decorator;
 class TestState implements Behavior.BlueshellState {
 	public errorReason?: Error;
 	public __blueshell: any;
+	public nodePath: string = '';
 }
 
 class TestAction extends Base<TestState, string> {
@@ -46,6 +47,20 @@ describe('Base', function() {
 			assert.ok(parent2);
 			assert.equal(leaf.path, 'parent2_foo_parent1_leaf');
 			assert.equal(parent1.path, 'parent2_foo_parent1');
+		});
+
+		it('updates the active node path', function() {
+			const leaf = new TestAction('leaf');
+			const parent1 = new Decorator('parent1', leaf);
+			const parent2 = new Decorator('parent2_foo', parent1);
+
+			const testState = new TestState();
+
+			assert.equal('', testState.nodePath);
+
+			parent2.handleEvent(testState, 'test event');
+
+			assert.equal(testState.nodePath, leaf.path);
 		});
 	});
 

--- a/test/nodes/Composite.test.ts
+++ b/test/nodes/Composite.test.ts
@@ -3,9 +3,11 @@
  */
 
 import {assert} from 'chai';
+import * as sinon from 'sinon';
 
 import {rc} from '../../lib';
 import {RobotState, waitAi} from './test/RobotActions';
+import {LatchedSelector, Constant} from '../../dist';
 
 describe('Composite', function() {
 	context('#resetNodeStorage', function() {
@@ -33,6 +35,24 @@ describe('Composite', function() {
 
 			// Normally would be 0
 			assert.equal(state.cooldownLevel, 1);
+		});
+
+		it('should call logging method', function() {
+			const state = new RobotState(false);
+			state.__blueshell.loggingCallback = sinon.stub();
+
+			const constantNode = new Constant('RUNNING', 'test success');
+			const selector = new LatchedSelector('testLatchedSelector', [
+				constantNode,
+			]);
+			let res = selector.handleEvent(state, 'test event');
+			assert.equal(res, rc.RUNNING);
+
+			(<any>constantNode).result = 'SUCCESS';
+
+			res = selector.handleEvent(state, 'test event 2');
+			assert.equal(res, rc.SUCCESS);
+			assert(state.__blueshell.loggingCallback.calledOnce, 'Logging callback not called');
 		});
 	});
 });

--- a/test/nodes/Constant.test.ts
+++ b/test/nodes/Constant.test.ts
@@ -6,14 +6,14 @@ import * as Behavior from '../../lib';
 describe('Success', function() {
 	it('Returns success, default name', function() {
 		const success = new Behavior.Constant(rc.SUCCESS);
-		assert.strictEqual(success.handleEvent({__blueshell: {}}, {}), rc.SUCCESS);
+		assert.strictEqual(success.handleEvent({__blueshell: {}, nodePath: ''}, {}), rc.SUCCESS);
 		assert.strictEqual(success.name, rc.SUCCESS);
 	});
 
 	it('Returns failure, custom name', function() {
 		const name = 'myname';
 		const failure = new Behavior.Constant(rc.FAILURE, name);
-		assert.strictEqual(failure.handleEvent({__blueshell: {}}, {}), rc.FAILURE);
+		assert.strictEqual(failure.handleEvent({__blueshell: {}, nodePath: ''}, {}), rc.FAILURE);
 		assert.strictEqual(failure.name, name);
 	});
 });

--- a/test/nodes/IfElse.test.ts
+++ b/test/nodes/IfElse.test.ts
@@ -11,6 +11,7 @@ class TestState implements Behavior.BlueshellState {
 	public failure: boolean = false;
 	public errorReason?: Error;
 	public __blueshell: any;
+	public nodePath: string = '';
 }
 
 describe('IfElse', function() {

--- a/test/nodes/IfElseWithNodeCondition.test.ts
+++ b/test/nodes/IfElseWithNodeCondition.test.ts
@@ -11,6 +11,7 @@ class TestState implements Behavior.BlueshellState {
 	public failureCount: number = 0;
 	public errorReason?: Error;
 	public __blueshell: any;
+	public nodePath: string = '';
 }
 
 class TestRunningAction extends Behavior.Action<TestState, string> {

--- a/test/nodes/Predicate.test.ts
+++ b/test/nodes/Predicate.test.ts
@@ -6,10 +6,10 @@ import * as Behavior from '../../lib';
 describe('Predicate', function() {
 	it('Turns truth into success', function() {
 		const p = new Behavior.Predicate('test', () => true);
-		assert.strictEqual(p.handleEvent({__blueshell: {}}, {}), rc.SUCCESS);
+		assert.strictEqual(p.handleEvent({__blueshell: {}, nodePath: ''}, {}), rc.SUCCESS);
 	});
 	it('Turns false into failure', function() {
 		const p = new Behavior.Predicate('test', () => false);
-		assert.strictEqual(p.handleEvent({__blueshell: {}}, {}), rc.FAILURE);
+		assert.strictEqual(p.handleEvent({__blueshell: {}, nodePath: ''}, {}), rc.FAILURE);
 	});
 });

--- a/test/nodes/RunningAction.test.ts
+++ b/test/nodes/RunningAction.test.ts
@@ -12,6 +12,7 @@ const RunningAction = Behavior.RunningAction;
 class TestState implements Behavior.BlueshellState {
 	public errorReason?: Error;
 	public __blueshell: any;
+	public nodePath: string = '';
 }
 
 class TestAction extends RunningAction<TestState, string> {

--- a/test/nodes/SideEffect.test.ts
+++ b/test/nodes/SideEffect.test.ts
@@ -9,11 +9,11 @@ describe('SideEffect', function() {
 		const s = new Behavior.SideEffect('set X', () => {
 			x = 3;
 		});
-		s.handleEvent({__blueshell: {}}, {});
+		s.handleEvent({__blueshell: {}, nodePath: ''}, {});
 		assert.strictEqual(x, 3);
 	});
 	it('Always succeeds if it completes', function() {
 		const s = new Behavior.SideEffect('set X', () => ({}));
-		assert.strictEqual(s.handleEvent({__blueshell: {}}, {}), rc.SUCCESS);
+		assert.strictEqual(s.handleEvent({__blueshell: {}, nodePath: ''}, {}), rc.SUCCESS);
 	});
 });

--- a/test/nodes/Success.test.ts
+++ b/test/nodes/Success.test.ts
@@ -6,6 +6,6 @@ import * as Behavior from '../../lib';
 describe('Success', function() {
 	it('Returns success', function() {
 		const success = new Behavior.Success();
-		assert.strictEqual(success.handleEvent({__blueshell: {}}, {}), rc.SUCCESS);
+		assert.strictEqual(success.handleEvent({__blueshell: {}, nodePath: ''}, {}), rc.SUCCESS);
 	});
 });

--- a/test/nodes/decorators/Retry.test.ts
+++ b/test/nodes/decorators/Retry.test.ts
@@ -31,6 +31,7 @@ describe('Retry ', function() {
 		const counter: RetryTestState = {
 			number: 0,
 			__blueshell: {},
+			nodePath: '',
 		};
 		const countUntil = new ResultReturner(rc.FAILURE);
 		const retry = new Behavior.decorators.Retry('RetryTest', countUntil, 2);
@@ -44,6 +45,7 @@ describe('Retry ', function() {
 		const counter: RetryTestState = {
 			number: 0,
 			__blueshell: {},
+			nodePath: '',
 		};
 		const countUntil = new ResultReturner(rc.FAILURE, 3);
 		const retry = new Behavior.decorators.Retry('RetryTest', countUntil, -1);

--- a/test/nodes/test/DroneActions.ts
+++ b/test/nodes/test/DroneActions.ts
@@ -6,6 +6,7 @@ export class DroneState implements BlueshellState {
 
 	public errorReason?: Error;
 	public __blueshell: any;
+	public nodePath: string = '';
 
 	constructor(debug: boolean = false) {
 		this.flares = 0;

--- a/test/nodes/test/RobotActions.ts
+++ b/test/nodes/test/RobotActions.ts
@@ -13,6 +13,7 @@ class RobotState implements Behavior.BlueshellState {
 
 	public errorReason?: Error;
 	public __blueshell: any;
+	public nodePath: string = '';
 
 	constructor(debug: boolean = false) {
 		this.overheated = false;

--- a/test/utils/renderTree.test.ts
+++ b/test/utils/renderTree.test.ts
@@ -75,7 +75,7 @@ describe('renderTree', function() {
 				state = {
 					errorReason: undefined,
 					__blueshell: {},
-					nodePath: '',				};
+					nodePath: ''};
 			});
 			function runContextDepthTest(
 				expectedNodes: number,

--- a/test/utils/renderTree.test.ts
+++ b/test/utils/renderTree.test.ts
@@ -69,12 +69,13 @@ describe('renderTree', function() {
 			let state: BlueshellState = {
 				errorReason: undefined,
 				__blueshell: {},
+				nodePath: '',
 			};
 			beforeEach(function() {
 				state = {
 					errorReason: undefined,
 					__blueshell: {},
-				};
+					nodePath: '',				};
 			});
 			function runContextDepthTest(
 				expectedNodes: number,


### PR DESCRIPTION
* adding a nodepath to the state object
* fixing the debugging flag for `npm run test:debug`
* adding a logging callback to be used when finishing a latched composite node