### PR TITLE
Generate api documentation and host as github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Decorators intercept and can modify the event sent to or the result from the chi
 
 * The publisher can be registered with the tree which will log each transition.
 
+## API Documentation
+You can find the latest Blueshell api documentation [here](https://6RiverSystems.github.io/blueshell/).
+
 ## Inspiration and Further Reading
 
 The following are sources used when designing this library

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "npm-run-all build:js",
+    "build:docs": "typedoc -out ./docs --githubPages true --hideGenerator true --cleanOutputDir true --entryPoints ./index.ts",
     "build:js": "tsc --pretty",
     "build:watch": "tsc --pretty --watch",
     "pretest": "npm-run-all build pretest:eslint",
@@ -52,9 +53,9 @@
     "@types/reflect-metadata": "0.1.0",
     "@types/sinon": "7.0.2",
     "@types/uuid": "3.4.4",
+    "@types/ws": "7.2.1",
     "@typescript-eslint/eslint-plugin": "4.28.5",
     "@typescript-eslint/parser": "4.28.5",
-    "@types/ws": "7.2.1",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "codecov": "3.8.2",
@@ -70,7 +71,7 @@
     "npm-run-all": "4.1.5",
     "nyc": "15.0.0",
     "sinon": "7.3.2",
-    "typedoc": "^0.22.6",
+    "typedoc": "^0.22.18",
     "typescript": "~4.3.5",
     "validate-commit-msg": "2.14.0"
   },


### PR DESCRIPTION
As a quick experiment I recently forked this repo solely to generate and host the api docs. The docs look pretty good (https://ros2jsguy.github.io/blueshell-docs/).  This PR proposes to rehome that small bit of work to the main repo. The commit will generate the api docs in html format. In addition, a user with admin privileges to this repo will need to enable github pages (under settings menu) on the repo and point to deployment folder, (./docs).     

package.json
- adds typedoc lib and build:doc script to generate api docs to a ./doc folder

README.md
- added a URL link to the git page where api docs are deployed.