### PR TITLE
fix: listen on explicit ipv4 localhost (LOL-3964)

### DIFF
--- a/lib/utils/nodeManager.ts
+++ b/lib/utils/nodeManager.ts
@@ -72,7 +72,10 @@ export class NodeManager<S extends BlueshellState, E>
 		this.session.post('Debugger.enable', () => undefined);
 
 		this.server = new Websocket.Server({
-			host: 'localhost',
+			// newer Ubuntu causes localhost to resolve to ipv6 ::1 preferably, and
+			// the server doesn't listen on both protocols, which breaks things like
+			// vscode remote development that only forward ipv4.
+			host: '127.0.0.1',
 			port: 8990,
 		});
 

--- a/test/utils/nodeManager.test.ts
+++ b/test/utils/nodeManager.test.ts
@@ -153,7 +153,7 @@ describe('nodeManager', function () {
 
 			nodeManager.runServer();
 			sinon.assert.calledWith(serverStub, {
-				host: 'localhost',
+				host: '127.0.0.1',
 				port: 8990,
 			});
 			serverMock.emit('connection', clientMock);


### PR DESCRIPTION
Since WS doesn't do multi-protocol listen, at least not in this version